### PR TITLE
Move python packages into requirements.txt

### DIFF
--- a/eeapi/Dockerfile
+++ b/eeapi/Dockerfile
@@ -2,9 +2,8 @@ FROM python:3
 
 WORKDIR /usr/src/app
 
-COPY requirements.txt ./
 RUN /usr/local/bin/python -m pip install --upgrade pip
-RUN pip install --no-cache-dir cherrypy mysql-connector-python pyyaml requests reportlab
+COPY requirements.txt ./
 RUN pip install --no-cache-dir -r requirements.txt
 
 COPY eeapi.py .

--- a/eeapi/requirements.txt
+++ b/eeapi/requirements.txt
@@ -1,1 +1,6 @@
-PyPDF2
+cherrypy == 18.8.0
+mysql-connector-python == 8.0.33
+PyPDF2 == 3.0.1
+pyyaml == 6.0
+reportlab == 4.0.4
+requests == 2.31.0


### PR DESCRIPTION
- So we can use the same req.txt for our dev environments
- Also pins versions